### PR TITLE
Add basic LinkedIn reply extension

### DIFF
--- a/linkedin-reply-extension/README.md
+++ b/linkedin-reply-extension/README.md
@@ -1,0 +1,14 @@
+# LinkedIn Reply Extension
+
+This Chrome extension adds a floating **Reply** button when browsing LinkedIn. Clicking the button focuses the message input area so you can quickly respond to a message.
+
+## Installation
+
+1. Open Chrome and navigate to `chrome://extensions/`.
+2. Enable **Developer mode** (top-right toggle).
+3. Click **Load unpacked** and choose this folder.
+4. Visit [LinkedIn](https://www.linkedin.com/) and you will see a **Reply** button in the bottom-right corner.
+
+## Usage
+
+Click the **Reply** button to focus the current message input box. If no input box is found, an alert will appear instead.

--- a/linkedin-reply-extension/content.js
+++ b/linkedin-reply-extension/content.js
@@ -1,0 +1,37 @@
+(function() {
+  function addReplyButton() {
+    if (document.getElementById('codex-reply-button')) return;
+    const btn = document.createElement('button');
+    btn.innerText = 'Reply';
+    btn.id = 'codex-reply-button';
+    btn.style.position = 'fixed';
+    btn.style.bottom = '10px';
+    btn.style.right = '10px';
+    btn.style.zIndex = 1000;
+    btn.style.padding = '8px 12px';
+    btn.style.background = '#0a66c2';
+    btn.style.color = '#fff';
+    btn.style.border = 'none';
+    btn.style.borderRadius = '4px';
+    btn.style.cursor = 'pointer';
+
+    btn.addEventListener('click', function() {
+      // Attempt to focus the active message input
+      const input = document.querySelector('div.msg-form__contenteditable');
+      if (input) {
+        input.focus();
+      } else {
+        alert('Reply clicked!');
+      }
+    });
+
+    document.body.appendChild(btn);
+  }
+
+  // run when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', addReplyButton);
+  } else {
+    addReplyButton();
+  }
+})();

--- a/linkedin-reply-extension/manifest.json
+++ b/linkedin-reply-extension/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "LinkedIn Reply Button",
+  "version": "1.0",
+  "description": "Adds a Reply button to LinkedIn messages.",
+  "permissions": ["activeTab", "scripting"],
+  "content_scripts": [
+    {
+      "matches": ["https://www.linkedin.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Chrome extension under `linkedin-reply-extension`
- extension injects a floating **Reply** button into LinkedIn pages
- README with loading instructions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885577766083299426a24e96a81d0a